### PR TITLE
Fix build issue for ARM with 32 bit integers

### DIFF
--- a/atime_linux_arm.go
+++ b/atime_linux_arm.go
@@ -1,5 +1,3 @@
-// +build arm
-
 package missinggo
 
 import (

--- a/atime_linux_arm.go
+++ b/atime_linux_arm.go
@@ -1,4 +1,4 @@
-// +build !arm
+// +build arm
 
 package missinggo
 
@@ -10,5 +10,5 @@ import (
 
 func fileInfoAccessTime(fi os.FileInfo) time.Time {
 	ts := fi.Sys().(*syscall.Stat_t).Atim
-	return time.Unix(ts.Sec, ts.Nsec)
+	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
 }


### PR DESCRIPTION
Just found this issue when trying to build on my Raspberry Pi. It appears that the ts.Sec and ts.Nsec are 32 bit integers on ARM and time.Unix() requires int64. I've just added a new atime_linux_arm.go file to cover this as I wasn't sure if just wrapping them in int64(ts.Sec) and int64(ts.Nsec) was going to be acceptable for builds that are potentially already 64 bit. I'm happy to change it around though if you prefer a different solution.